### PR TITLE
Fix nGraph backend registration issue

### DIFF
--- a/ngraph_onnx/onnx_importer/backend.py
+++ b/ngraph_onnx/onnx_importer/backend.py
@@ -39,7 +39,6 @@ from ngraph_onnx.onnx_importer.importer import import_onnx_model
 class NgraphBackend(Backend):
     """Takes an ONNX model with inputs, perform a computation, and then return the output."""
 
-    _ngraph_supported_devices = []  # type: List[str]
     # The requested (nGraph) backend to be used instead of hardcoded by ONNX test Runner.
     backend_name = None  # type: str
 
@@ -61,12 +60,6 @@ class NgraphBackend(Backend):
         return NgraphBackendRep(ng_model, cls.backend_name)
 
     @classmethod
-    def _get_supported_devices(cls):  # type: () -> List[str]
-        if len(cls._ngraph_supported_devices) == 0:
-            cls._ngraph_supported_devices = ng.impl.runtime.Backend.get_registered_devices()
-        return cls._ngraph_supported_devices
-
-    @classmethod
     def _get_onnx_device_name(cls, ngraph_device_name):  # type: (str) -> Optional[str]
         return next((onnx_device for (ng_device, onnx_device) in cls._ngraph_onnx_device_map
                      if ngraph_device_name == ng_device), None)
@@ -78,7 +71,11 @@ class NgraphBackend(Backend):
         :param ngraph_device_name: Name of nGraph device.
         :return: True if current nGraph library supports ngraph_device_name.
         """
-        return ngraph_device_name in cls._get_supported_devices()
+        try:
+            ng.runtime(backend_name=ngraph_device_name)
+        except RuntimeError:
+            return False
+        return True
 
     @classmethod
     def supports_device(cls, onnx_device_name):  # type: (str) -> bool

--- a/ngraph_onnx/onnx_importer/backend.py
+++ b/ngraph_onnx/onnx_importer/backend.py
@@ -65,16 +65,22 @@ class NgraphBackend(Backend):
                      if ngraph_device_name == ng_device), None)
 
     @classmethod
+    def _get_supported_devices(cls):  # type: () -> List[str]
+        return ng.impl.runtime.Backend.get_registered_devices()
+
+    @classmethod
     def supports_ngraph_device(cls, ngraph_device_name):  # type: (str) -> bool
         """Check whether particular nGraph device is supported by current nGraph library.
 
         :param ngraph_device_name: Name of nGraph device.
         :return: True if current nGraph library supports ngraph_device_name.
         """
-        try:
-            ng.runtime(backend_name=ngraph_device_name)
-        except RuntimeError:
-            return False
+        # Check whether the backend was already created and if not try to create it.
+        if ngraph_device_name not in cls._get_supported_devices():
+            try:
+                ng.runtime(backend_name=ngraph_device_name)
+            except RuntimeError:
+                return False
         return True
 
     @classmethod


### PR DESCRIPTION
Cause:
At current version of nGraph backends are registered lazily at the very moment of the attempt of its creation. This caused that the call to `ng.impl.runtime.Backend.get_registered_devices()` before any such attempt returned empty list. 

Solution:
When current list of registered devices doesn't contain requested backend then attempt to create such backend.