### PR TITLE
Optimize generated graph for GEMM

### DIFF
--- a/ngraph_onnx/onnx_importer/ops_bridge.py
+++ b/ngraph_onnx/onnx_importer/ops_bridge.py
@@ -542,9 +542,11 @@ def Gemm(onnx_node, ng_inputs):  # type: (NodeWrapper, List[NgraphNode]) -> Ngra
     if not broadcast and input_c.shape != a_dot_b.shape:
         raise ValueError('Gemm node (%s): input data shapes are incompatible and broadcast '
                          ' was not requested!', onnx_node.name)
-
-    return alpha * a_dot_b + beta * input_c
-
+    if alpha != 1:
+        a_dot_b = alpha *a_dot_b
+    if beta != 1:
+        input_c = beta * input_c
+    return a_dot_b + input_c
 
 def Dropout(onnx_node, ng_inputs):  # type: (NodeWrapper, List[NgraphNode]) -> NgraphNode
     """Dropout [inference only].

--- a/ngraph_onnx/onnx_importer/ops_bridge.py
+++ b/ngraph_onnx/onnx_importer/ops_bridge.py
@@ -32,12 +32,12 @@ import ngraph as ng
 from ngraph_onnx.onnx_importer.utils.binary import broadcast_for_binary_operation
 from ngraph_onnx.onnx_importer.utils.conv import make_convolution_op
 from ngraph_onnx.onnx_importer.utils.decorators import refactoring_required
-from ngraph_onnx.onnx_importer.utils.matmul import has_matmul_compatible_shapes
+from ngraph_onnx.onnx_importer.utils.matmul import reshape_for_matmul
 from ngraph_onnx.onnx_importer.utils.misc import split_pads_into_pairs
 from ngraph_onnx.onnx_importer.utils.pool import make_pooling_op, make_global_pooling_op
 from ngraph_onnx.onnx_importer.utils.reduction import make_reduction_op, get_reduction_axes
 from ngraph_onnx.onnx_importer.utils.reshape import transpose, infer_dimensions, \
-    flatten_innermost_empty_dims, reorder_axes, make_slice_op, flatten
+    reorder_axes, make_slice_op, flatten
 
 if TYPE_CHECKING:
     from ngraph_onnx.onnx_importer.model_wrappers import NodeWrapper
@@ -525,17 +525,7 @@ def Gemm(onnx_node, ng_inputs):  # type: (NodeWrapper, List[NgraphNode]) -> Ngra
     if trans_b:
         input_b = transpose(input_b)
 
-    # onnx-tensorflow: https://github.com/onnx/onnx-tensorflow/
-    #  blob/17075f44c9071600beccfc62c92b22d1cd957bfd/onnx_tf/backend.py#L711
-    # They have hardcoded flatten input `A` before transposition.
-    #
-    # Firstly, we check whether input data have incompatible shapes and then try flatten input data.
-    if not has_matmul_compatible_shapes(input_a.shape, input_b.shape):
-        input_a = flatten(input_a, 1)  # Flatten ND tensors to 2D matrices
-        input_b = flatten(input_b, 1)
-        if not has_matmul_compatible_shapes(input_a.shape, input_b.shape):
-            raise ValueError('Gemm node (%s): input "A" and "B" data shapes are incompatible to '
-                             'multiply with each other.', onnx_node.name)
+    input_a, input_b = reshape_for_matmul(onnx_node, input_a, input_b)
 
     a_dot_b = ng.dot(input_a, input_b)
 
@@ -543,10 +533,13 @@ def Gemm(onnx_node, ng_inputs):  # type: (NodeWrapper, List[NgraphNode]) -> Ngra
         raise ValueError('Gemm node (%s): input data shapes are incompatible and broadcast '
                          ' was not requested!', onnx_node.name)
     if alpha != 1:
-        a_dot_b = alpha *a_dot_b
+        a_dot_b = alpha * a_dot_b
+
     if beta != 1:
         input_c = beta * input_c
+
     return a_dot_b + input_c
+
 
 def Dropout(onnx_node, ng_inputs):  # type: (NodeWrapper, List[NgraphNode]) -> NgraphNode
     """Dropout [inference only].

--- a/ngraph_onnx/onnx_importer/utils/matmul.py
+++ b/ngraph_onnx/onnx_importer/utils/matmul.py
@@ -18,8 +18,11 @@ from typing import Tuple
 from ngraph.utils.types import TensorShape
 from ngraph.impl import Node as NgraphNode
 
-from ngraph_onnx.onnx_importer.model_wrappers import NodeWrapper
+from ngraph_onnx import TYPE_CHECKING
 from ngraph_onnx.onnx_importer.utils.reshape import flatten
+
+if TYPE_CHECKING:
+    from ngraph_onnx.onnx_importer.model_wrappers import NodeWrapper
 
 
 def _is_matrix(shape):  # type: (TensorShape) -> bool

--- a/ngraph_onnx/onnx_importer/utils/matmul.py
+++ b/ngraph_onnx/onnx_importer/utils/matmul.py
@@ -13,8 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ******************************************************************************
+from typing import Tuple
 
 from ngraph.utils.types import TensorShape
+from ngraph.impl import Node as NgraphNode
+
+from ngraph_onnx.onnx_importer.model_wrappers import NodeWrapper
+from ngraph_onnx.onnx_importer.utils.reshape import flatten
 
 
 def _is_matrix(shape):  # type: (TensorShape) -> bool
@@ -35,7 +40,7 @@ def _is_vector(shape):  # type: (TensorShape) -> bool
 
 def has_matmul_compatible_shapes(shape_a, shape_b):  # noqa: C901
     # type: (TensorShape, TensorShape) -> bool
-    # FIXME: C901 too comples function
+    # FIXME: C901 function too complex
     """Check wheter input tensors have compatible shapes to multiply A @ B.
 
     Shape requirements are defined by NumPy.matmul function. They boil down to:
@@ -107,3 +112,26 @@ def has_matmul_compatible_shapes(shape_a, shape_b):  # noqa: C901
             return False
 
     return True
+
+
+def reshape_for_matmul(onnx_node, input_a, input_b):
+    # type: (NodeWrapper, NgraphNode, NgraphNode) -> Tuple[NgraphNode, NgraphNode]
+    """Adjust input tensor shapes for matrix multiplication.
+
+    This is based on an idea from onnx-tensorflow
+    https://github.com/onnx/onnx-tensorflow/blob/17075f44c9071600beccfc62c92b22d1cd957bfd/onnx_tf/backend.py#L711
+    They have hardcoded flatten input `A` before transposition.
+
+    :param onnx_node: ONNX node for the matrix multiplication operation
+    :param input_a: left side input node
+    :param input_b: right side input node
+    :return: tuple with input_a and input_b reshaped if needed
+    """
+    # First we check whether input data have incompatible shapes and then try flatten input data.
+    if not has_matmul_compatible_shapes(input_a.shape, input_b.shape):
+        input_a = flatten(input_a, 1)  # Flatten ND tensors to 2D matrices
+        input_b = flatten(input_b, 1)
+        if not has_matmul_compatible_shapes(input_a.shape, input_b.shape):
+            raise ValueError('%s node (%s): input "A" and "B" data shapes are incompatible to '
+                             'multiply with each other.', onnx_node.op_type, onnx_node.name)
+    return input_a, input_b


### PR DESCRIPTION
in inception_v2 the generated graph is very complex and hard to fuse.
This change avoid generating a complex graph if there is no need to.