### PR TITLE
Support for ONNX operator versions sets 2-5

### DIFF
--- a/ngraph_onnx/onnx_importer/ops_bridge/opset_01.py
+++ b/ngraph_onnx/onnx_importer/ops_bridge/opset_01.py
@@ -592,32 +592,27 @@ def ConvTranspose(onnx_node, ng_inputs):  # type: (NodeWrapper, List[NgraphNode]
 
 def Pad(onnx_node, ng_inputs):  # type: (NodeWrapper, List[NgraphNode]) -> NgraphNode
     """Add padding to the input tensor."""
-    # Oprator set version 1
     paddings = onnx_node.get_attribute_value('paddings')
-    # Operator set version >= 2
-    pads = onnx_node.get_attribute_value('pads')
-
-    pads = pads if pads is not None else paddings
-    if pads is None:
+    if paddings is None:
         raise ValueError('Pad node (s%): paddings attribute is required.', onnx_node.name)
 
     constant = 'constant'
     mode = onnx_node.get_attribute_value('mode', constant)  # 'constant', 'reflect' or 'edge'
     value = onnx_node.get_attribute_value('value', 0.)
 
-    if len(pads) != 2 * len(ng_inputs[0].shape):
+    if len(paddings) != 2 * len(ng_inputs[0].shape):
         raise ValueError('Pad node (%s): \'paddings rank (%d) should be double of input tensor '
-                         'rank (%d).', onnx_node.name, len(pads), len(ng_inputs[0].shape))
+                         'rank (%d).', onnx_node.name, len(paddings), len(ng_inputs[0].shape))
 
     # Operator set version >= 2
-    if any(map(lambda x: x < 0, pads)):
-        raise NotImplementedError('Pad node (%s): removing padding elements is not supported yet.',
-                                  onnx_node.name)
+    if any(map(lambda x: x < 0, paddings)):
+        raise ValueError('Pad node (%s): supports only addition of padding elements.',
+                         onnx_node.name)
     if mode != constant:
         raise NotImplementedError('Pad node (%s): only constant padding is supported.', onnx_node.name)
 
     # Split paddings into pairs for each axis
-    pading_below, pading_above = split_pads_into_pairs(pads)
+    pading_below, pading_above = split_pads_into_pairs(paddings)
     return ng.pad(ng_inputs[0], ng.constant(value,
                   dtype=get_dtype(ng_inputs[0].get_element_type())), pading_below, pading_above)
 

--- a/ngraph_onnx/onnx_importer/ops_bridge/opset_01.py
+++ b/ngraph_onnx/onnx_importer/ops_bridge/opset_01.py
@@ -869,3 +869,9 @@ def Size(onnx_node, ng_inputs):  # type: (NodeWrapper, List[NgraphNode]) -> Ngra
     """Return input size."""
     # Dtype int64 is required for ONNX unit tests.
     return ng.constant(flatten(ng_inputs[0], 0).shape[1], dtype=np.int64)
+
+
+@refactoring_required
+def GRU(onnx_node, ng_inputs):  # type: (NodeWrapper, List[NgraphNode]) -> NgraphNode
+    """Return node performing GRU operation."""
+    return None

--- a/ngraph_onnx/onnx_importer/ops_bridge/opset_01.py
+++ b/ngraph_onnx/onnx_importer/ops_bridge/opset_01.py
@@ -719,8 +719,7 @@ def Concat(onnx_node, ng_inputs):  # type: (NodeWrapper, List[NgraphNode]) -> Ng
         raise ValueError('Concat node (%s): requires "axis" attribute', onnx_node.name)
 
     if len(ng_inputs) < 2:
-        raise ValueError('Concat node (%s): requires at least 2 inputs, %d given.',
-                         onnx_node.name, len(ng_inputs))
+        return ng_inputs[0]
 
     unique_input_ranks = {len(node.shape) for node in ng_inputs}
     if len(unique_input_ranks) != 1:

--- a/ngraph_onnx/onnx_importer/ops_bridge/opset_01.py
+++ b/ngraph_onnx/onnx_importer/ops_bridge/opset_01.py
@@ -619,7 +619,7 @@ def Pad(onnx_node, ng_inputs):  # type: (NodeWrapper, List[NgraphNode]) -> Ngrap
         raise ValueError('Pad node (%s): \'paddings rank (%d) should be double of input tensor '
                          'rank (%d).', onnx_node.name, len(paddings), len(ng_inputs[0].shape))
 
-    # Operator set version >= 2
+    # check for negative padding values
     if any(map(lambda x: x < 0, paddings)):
         raise ValueError('Pad node (%s): supports only addition of padding elements.',
                          onnx_node.name)

--- a/ngraph_onnx/onnx_importer/ops_bridge/opset_01.py
+++ b/ngraph_onnx/onnx_importer/ops_bridge/opset_01.py
@@ -606,11 +606,27 @@ def ConvTranspose(onnx_node, ng_inputs):  # type: (NodeWrapper, List[NgraphNode]
 
 def Pad(onnx_node, ng_inputs):  # type: (NodeWrapper, List[NgraphNode]) -> NgraphNode
     """Add padding to the input tensor."""
+    # Oprator set version 1
+    paddings = onnx_node.get_attribute_value('paddings')
+    # Operator set version >= 2
     pads = onnx_node.get_attribute_value('pads')
+
+    pads = pads if pads is not None else paddings
+    if pads is None:
+        raise ValueError('Pad node (s%): paddings attribute is required.', onnx_node.name)
+
     constant = 'constant'
     mode = onnx_node.get_attribute_value('mode', constant)  # 'constant', 'reflect' or 'edge'
-    value = onnx_node.get_attribute_value('value', 0)
+    value = onnx_node.get_attribute_value('value', 0.)
 
+    if len(pads) != 2 * len(ng_inputs[0].shape):
+        raise ValueError('Pad node (%s): \'paddings rank (%d) should be double of input tensor '
+                         'rank (%d).', onnx_node.name, len(pads), len(ng_inputs[0].shape))
+
+    # Operator set version >= 2
+    if any(map(lambda x: x < 0, pads)):
+        raise NotImplementedError('Pad node (%s): removing padding elements is not supported yet.',
+                                  onnx_node.name)
     if mode != constant:
         raise NotImplementedError('Pad node (%s): only constant padding is supported.', onnx_node.name)
 

--- a/ngraph_onnx/onnx_importer/ops_bridge/opset_01.py
+++ b/ngraph_onnx/onnx_importer/ops_bridge/opset_01.py
@@ -410,20 +410,6 @@ def ReduceL2(onnx_node, ng_inputs):  # type: (NodeWrapper, List[NgraphNode]) -> 
     return ng.sqrt(sum_node)
 
 
-@refactoring_required
-def ArgMin(onnx_node, ng_inputs):  # type: (NodeWrapper, List[NgraphNode]) -> NgraphNode
-    """Compute the indices of the min elements of the input tensor along the provided axes."""
-    return None  # tmp
-    # return make_reduction_op(ng.argmin, onnx_node, ng_inputs[0])
-
-
-@refactoring_required
-def ArgMax(onnx_node, ng_inputs):  # type: (NodeWrapper, List[NgraphNode]) -> NgraphNode
-    """Compute the indices of the max elements of the input tensor along the provided axes."""
-    return None  # tmp
-    # return make_reduction_op(ng.argmax, onnx_node, ng_inputs[0])
-
-
 # Binary Ops
 def Add(onnx_node, ng_inputs):  # type: (NodeWrapper, List[NgraphNode]) -> NgraphNode
     """Perform element-wise binary addition."""
@@ -868,9 +854,3 @@ def Size(onnx_node, ng_inputs):  # type: (NodeWrapper, List[NgraphNode]) -> Ngra
     """Return input size."""
     # Dtype int64 is required for ONNX unit tests.
     return ng.constant(flatten(ng_inputs[0], 0).shape[1], dtype=np.int64)
-
-
-@refactoring_required
-def GRU(onnx_node, ng_inputs):  # type: (NodeWrapper, List[NgraphNode]) -> NgraphNode
-    """Return node performing GRU operation."""
-    return None

--- a/ngraph_onnx/onnx_importer/ops_bridge/opset_02.py
+++ b/ngraph_onnx/onnx_importer/ops_bridge/opset_02.py
@@ -14,4 +14,9 @@
 # limitations under the License.
 # ******************************************************************************
 
+# TODO: GlobalLpPool-2  
+# TODO: LpPool-2        
+# Pad-2                 supported by opset_01.Pad
+# Split-2               supported by opset_01.Split
+
 from ngraph_onnx.onnx_importer.ops_bridge.opset_01 import *  # noqa

--- a/ngraph_onnx/onnx_importer/ops_bridge/opset_02.py
+++ b/ngraph_onnx/onnx_importer/ops_bridge/opset_02.py
@@ -14,8 +14,8 @@
 # limitations under the License.
 # ******************************************************************************
 
-# TODO: GlobalLpPool-2  
-# TODO: LpPool-2        
+# TODO: GlobalLpPool-2
+# TODO: LpPool-2
 # Pad-2                 supported by opset_01.Pad
 # Split-2               supported by opset_01.Split
 

--- a/ngraph_onnx/onnx_importer/ops_bridge/opset_02.py
+++ b/ngraph_onnx/onnx_importer/ops_bridge/opset_02.py
@@ -30,10 +30,8 @@ from ngraph.utils.types import get_dtype
 from ngraph.impl import Node as NgraphNode
 from ngraph_onnx.onnx_importer.utils.misc import split_pads_into_pairs
 
-
 if TYPE_CHECKING:
     from ngraph_onnx.onnx_importer.model_wrappers import NodeWrapper
-
 
 from ngraph_onnx.onnx_importer.ops_bridge.opset_01 import *  # noqa
 

--- a/ngraph_onnx/onnx_importer/ops_bridge/opset_02.py
+++ b/ngraph_onnx/onnx_importer/ops_bridge/opset_02.py
@@ -51,6 +51,7 @@ def Pad(onnx_node, ng_inputs):  # type: (NodeWrapper, List[NgraphNode]) -> Ngrap
         raise ValueError('Pad node (%s): \'pads rank (%d) should be double of input tensor '
                          'rank (%d).', onnx_node.name, len(pads), len(ng_inputs[0].shape))
 
+    # check for negative pads values
     if any(map(lambda x: x < 0, pads)):
         raise NotImplementedError('Pad node (%s): removing padding elements is not supported yet.',
                                   onnx_node.name)

--- a/ngraph_onnx/onnx_importer/ops_bridge/opset_02.py
+++ b/ngraph_onnx/onnx_importer/ops_bridge/opset_02.py
@@ -16,49 +16,7 @@
 
 # TODO: GlobalLpPool-2
 # TODO: LpPool-2
+# Pad-2                 supported by opset_01.Pad
 # Split-2               supported by opset_01.Split
 
-from __future__ import print_function
-from __future__ import division
-
-from typing import Tuple, List
-
-import ngraph as ng
-
-from ngraph_onnx import TYPE_CHECKING
-from ngraph.utils.types import get_dtype
-from ngraph.impl import Node as NgraphNode
-from ngraph_onnx.onnx_importer.utils.misc import split_pads_into_pairs
-
-if TYPE_CHECKING:
-    from ngraph_onnx.onnx_importer.model_wrappers import NodeWrapper
-
 from ngraph_onnx.onnx_importer.ops_bridge.opset_01 import *  # noqa
-
-
-def Pad(onnx_node, ng_inputs):  # type: (NodeWrapper, List[NgraphNode]) -> NgraphNode
-    """Add padding to the input tensor."""
-    pads = onnx_node.get_attribute_value('pads')
-
-    if pads is None:
-        raise ValueError('Pad node (s%): pads attribute is required.', onnx_node.name)
-
-    constant = 'constant'
-    mode = onnx_node.get_attribute_value('mode', constant)  # 'constant', 'reflect' or 'edge'
-    value = onnx_node.get_attribute_value('value', 0.)
-
-    if len(pads) != 2 * len(ng_inputs[0].shape):
-        raise ValueError('Pad node (%s): \'pads rank (%d) should be double of input tensor '
-                         'rank (%d).', onnx_node.name, len(pads), len(ng_inputs[0].shape))
-
-    # check for negative pads values
-    if any(map(lambda x: x < 0, pads)):
-        raise NotImplementedError('Pad node (%s): removing padding elements is not supported yet.',
-                                  onnx_node.name)
-    if mode != constant:
-        raise NotImplementedError('Pad node (%s): only constant padding is supported.', onnx_node.name)
-
-    # Split pads into pairs for each axis
-    pading_below, pading_above = split_pads_into_pairs(pads)
-    return ng.pad(ng_inputs[0], ng.constant(value,
-                  dtype=get_dtype(ng_inputs[0].get_element_type())), pading_below, pading_above)

--- a/ngraph_onnx/onnx_importer/ops_bridge/opset_02.py
+++ b/ngraph_onnx/onnx_importer/ops_bridge/opset_02.py
@@ -16,7 +16,50 @@
 
 # TODO: GlobalLpPool-2
 # TODO: LpPool-2
-# Pad-2                 supported by opset_01.Pad
 # Split-2               supported by opset_01.Split
 
+from __future__ import print_function
+from __future__ import division
+
+from typing import Tuple, List
+
+import ngraph as ng
+
+from ngraph_onnx import TYPE_CHECKING
+from ngraph.utils.types import get_dtype
+from ngraph.impl import Node as NgraphNode
+from ngraph_onnx.onnx_importer.utils.misc import split_pads_into_pairs
+
+
+if TYPE_CHECKING:
+    from ngraph_onnx.onnx_importer.model_wrappers import NodeWrapper
+
+
 from ngraph_onnx.onnx_importer.ops_bridge.opset_01 import *  # noqa
+
+
+def Pad(onnx_node, ng_inputs):  # type: (NodeWrapper, List[NgraphNode]) -> NgraphNode
+    """Add padding to the input tensor."""
+    pads = onnx_node.get_attribute_value('pads')
+
+    if pads is None:
+        raise ValueError('Pad node (s%): pads attribute is required.', onnx_node.name)
+
+    constant = 'constant'
+    mode = onnx_node.get_attribute_value('mode', constant)  # 'constant', 'reflect' or 'edge'
+    value = onnx_node.get_attribute_value('value', 0.)
+
+    if len(pads) != 2 * len(ng_inputs[0].shape):
+        raise ValueError('Pad node (%s): \'pads rank (%d) should be double of input tensor '
+                         'rank (%d).', onnx_node.name, len(pads), len(ng_inputs[0].shape))
+
+    if any(map(lambda x: x < 0, pads)):
+        raise NotImplementedError('Pad node (%s): removing padding elements is not supported yet.',
+                                  onnx_node.name)
+    if mode != constant:
+        raise NotImplementedError('Pad node (%s): only constant padding is supported.', onnx_node.name)
+
+    # Split pads into pairs for each axis
+    pading_below, pading_above = split_pads_into_pairs(pads)
+    return ng.pad(ng_inputs[0], ng.constant(value,
+                  dtype=get_dtype(ng_inputs[0].get_element_type())), pading_below, pading_above)

--- a/ngraph_onnx/onnx_importer/ops_bridge/opset_03.py
+++ b/ngraph_onnx/onnx_importer/ops_bridge/opset_03.py
@@ -14,4 +14,6 @@
 # limitations under the License.
 # ******************************************************************************
 
+# TODO: GRU-3
+
 from ngraph_onnx.onnx_importer.ops_bridge.opset_02 import *  # noqa

--- a/ngraph_onnx/onnx_importer/ops_bridge/opset_04.py
+++ b/ngraph_onnx/onnx_importer/ops_bridge/opset_04.py
@@ -14,4 +14,6 @@
 # limitations under the License.
 # ******************************************************************************
 
+# Concat-4 supported by opset_03.Concat
+
 from ngraph_onnx.onnx_importer.ops_bridge.opset_03 import *  # noqa

--- a/ngraph_onnx/onnx_importer/ops_bridge/opset_04.py
+++ b/ngraph_onnx/onnx_importer/ops_bridge/opset_04.py
@@ -14,6 +14,6 @@
 # limitations under the License.
 # ******************************************************************************
 
-# Concat-4 supported by opset_03.Concat
+# Concat-4 supported by opset_01.Concat
 
 from ngraph_onnx.onnx_importer.ops_bridge.opset_03 import *  # noqa

--- a/ngraph_onnx/onnx_importer/ops_bridge/opset_05.py
+++ b/ngraph_onnx/onnx_importer/ops_bridge/opset_05.py
@@ -15,3 +15,14 @@
 # ******************************************************************************
 
 from ngraph_onnx.onnx_importer.ops_bridge.opset_04 import *  # noqa
+
+
+def Reshape(onnx_node, ng_inputs):  # type: (NodeWrapper, List[NgraphNode]) -> NgraphNode
+    """Reshape the input tensor similar to numpy.reshape.
+
+    At most one dimension of the new shape can be -1. In this case, the value is inferred from
+    the size of the tensor and the remaining dimensions. A dimension could also be 0, in which
+    case the actual dimension value is going to be copied from the shape argument.
+    """
+    raise NotImplementedError('Reshape node (%s) - dynamic output shape is not supported yet.',
+                              onnx_node.name)

--- a/tests/test_ops_convpool.py
+++ b/tests/test_ops_convpool.py
@@ -227,11 +227,6 @@ def test_pad_opset_1():
     with pytest.raises(ValueError):
         run_model(model, [x])
 
-    # negative paddings values
-    model = get_node_model('Pad', x, paddings=[0, -1, -1, 3])
-    with pytest.raises(ValueError):
-        run_model(model, [x])
-
     # no paddings arttribute
     model = get_node_model('Pad', x)
     with pytest.raises(ValueError):

--- a/tests/test_ops_convpool.py
+++ b/tests/test_ops_convpool.py
@@ -206,7 +206,39 @@ def test_2d_conv_transpose():
                                    dtype=np.float32))
 
 
-def test_padding():
+def test_pad_opset_1():
+    x = np.ones((2, 2), dtype=np.float32)
+    y = np.pad(x, pad_width=1, mode='constant')
+
+    model = get_node_model('Pad', x, paddings=[1, 1, 1, 1])
+    ng_results = run_model(model, [x])
+    assert np.array_equal(ng_results, [y])
+
+    x = np.random.randn(1, 3, 4, 5).astype(np.float32)
+    y = np.pad(x, pad_width=((0, 0), (0, 0), (1, 2), (3, 4)), mode='constant')
+
+    model = get_node_model('Pad', x, mode='constant', paddings=[0, 0, 1, 3, 0, 0, 2, 4])
+    ng_results = run_model(model, [x])
+    assert np.array_equal(ng_results, [y])
+
+    # incorrect paddings rank
+    x = np.ones((2, 2), dtype=np.float32)
+    model = get_node_model('Pad', x, paddings=[0, 1, 1, 3, 1, 2])
+    with pytest.raises(ValueError):
+        run_model(model, [x])
+
+    # negative paddings values
+    model = get_node_model('Pad', x, paddings=[0, -1, -1, 3])
+    with pytest.raises(ValueError):
+        run_model(model, [x])
+
+    # no paddings arttribute
+    model = get_node_model('Pad', x)
+    with pytest.raises(ValueError):
+        import_onnx_model(model)[0]
+
+
+def test_pad_opset_2():
     x = np.ones((2, 2), dtype=np.float32)
     y = np.pad(x, pad_width=1, mode='constant')
 
@@ -217,34 +249,22 @@ def test_padding():
     x = np.random.randn(1, 3, 4, 5).astype(np.float32)
     y = np.pad(x, pad_width=((0, 0), (0, 0), (1, 2), (3, 4)), mode='constant')
 
-    # Opset version 2
     model = get_node_model('Pad', x, opset=2, mode='constant', pads=[0, 0, 1, 3, 0, 0, 2, 4])
     ng_results = run_model(model, [x])
     assert np.array_equal(ng_results, [y])
 
-    # Opset version 1
-    model = get_node_model('Pad', x, mode='constant', paddings=[0, 0, 1, 3, 0, 0, 2, 4])
-    ng_results = run_model(model, [x])
-    assert np.array_equal(ng_results, [y])
-
-    # incorrect paddings rank
+    # incorrect pads rank
     x = np.ones((2, 2), dtype=np.float32)
     model = get_node_model('Pad', x, opset=2, pads=[0, 1, 1, 3, 1, 2])
     with pytest.raises(ValueError):
         run_model(model, [x])
 
-    # negative paddings values
-    x = np.ones((2, 2), dtype=np.float32)
+    # negative pads values
     model = get_node_model('Pad', x, opset=2, pads=[0, -1, -1, 3])
     with pytest.raises(NotImplementedError):
         run_model(model, [x])
 
-    # no pads provided operation set 1
-    model = get_node_model('Pad', x)
-    with pytest.raises(ValueError):
-        import_onnx_model(model)[0]
-
-    # no pads provided operation set 2
+    # no pads attribute
     model = get_node_model('Pad', x, opset=2)
     with pytest.raises(ValueError):
         import_onnx_model(model)[0]

--- a/tests/test_ops_convpool.py
+++ b/tests/test_ops_convpool.py
@@ -22,7 +22,7 @@ import pytest
 import numpy as np
 from onnx.helper import make_node, make_graph, make_tensor_value_info, make_model
 from ngraph_onnx.onnx_importer.importer import import_onnx_model
-from tests.utils import run_node, get_runtime
+from tests.utils import run_model, run_node, get_node_model, get_runtime
 
 
 @pytest.fixture
@@ -207,20 +207,47 @@ def test_2d_conv_transpose():
 
 
 def test_padding():
-    node = onnx.helper.make_node('Pad', inputs=['x'], outputs=['y'], pads=[1, 1, 1, 1])
     x = np.ones((2, 2), dtype=np.float32)
     y = np.pad(x, pad_width=1, mode='constant')
 
-    ng_results = run_node(node, [x])
+    model = get_node_model('Pad', x, opset=2, pads=[1, 1, 1, 1])
+    ng_results = run_model(model, [x])
     assert np.array_equal(ng_results, [y])
 
-    node = onnx.helper.make_node('Pad', inputs=['x'], outputs=['y'],
-                                 mode='constant', pads=[0, 0, 1, 3, 0, 0, 2, 4])
     x = np.random.randn(1, 3, 4, 5).astype(np.float32)
     y = np.pad(x, pad_width=((0, 0), (0, 0), (1, 2), (3, 4)), mode='constant')
 
-    ng_results = run_node(node, [x])
+    # Opset version 2
+    model = get_node_model('Pad', x, opset=2, mode='constant', pads=[0, 0, 1, 3, 0, 0, 2, 4])
+    ng_results = run_model(model, [x])
     assert np.array_equal(ng_results, [y])
+
+    # Opset version 1
+    model = get_node_model('Pad', x, mode='constant', paddings=[0, 0, 1, 3, 0, 0, 2, 4])
+    ng_results = run_model(model, [x])
+    assert np.array_equal(ng_results, [y])
+
+    # incorrect paddings rank
+    x = np.ones((2, 2), dtype=np.float32)
+    model = get_node_model('Pad', x, opset=2, pads=[0, 1, 1, 3, 1, 2])
+    with pytest.raises(ValueError):
+        run_model(model, [x])
+
+    # negative paddings values
+    x = np.ones((2, 2), dtype=np.float32)
+    model = get_node_model('Pad', x, opset=2, pads=[0, -1, -1, 3])
+    with pytest.raises(NotImplementedError):
+        run_model(model, [x])
+
+    # no pads provided operation set 1
+    model = get_node_model('Pad', x)
+    with pytest.raises(ValueError):
+        import_onnx_model(model)[0]
+
+    # no pads provided operation set 2
+    model = get_node_model('Pad', x, opset=2)
+    with pytest.raises(ValueError):
+        import_onnx_model(model)[0]
 
 
 def test_pool_average(ndarray_1x1x4x4):

--- a/tests/test_reshape.py
+++ b/tests/test_reshape.py
@@ -126,6 +126,11 @@ def test_slice():
 def test_concat():
     a = np.array([[1, 2], [3, 4]])
     b = np.array([[5, 6]])
+
+    node = onnx.helper.make_node('Concat', inputs=['x'], outputs=['z'], axis=0)
+    ng_results = run_node(node, [a])
+    assert np.array_equal(ng_results, [a])
+
     expected_output = np.concatenate((a, b), axis=0)
     node = onnx.helper.make_node('Concat', inputs=['x', 'y'], outputs=['z'], axis=0)
     ng_results = run_node(node, [a, b])

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -66,7 +66,7 @@ def run_model(onnx_model, data_inputs):
 
 
 def get_node_model(op_type, *input_data, opset=1, num_outputs=1, **node_attributes):
-    # type: (str, Any, Optional[int], Optional[int], Optional[Any]) -> onnx.ModelProto
+    # type: (str, *Any, Optional[int], Optional[int], **Any) -> onnx.ModelProto
     """Generate model with single requested node.
 
     :param op_type: The ONNX node operation.

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -16,11 +16,15 @@
 
 from __future__ import print_function, division
 
+import onnx
 import numpy as np
 import pytest
 
 import ngraph as ng
+
+from onnx.helper import make_node, make_graph, make_tensor_value_info, make_model
 from ngraph_onnx.onnx_importer.backend import NgraphBackend
+from string import ascii_uppercase
 
 
 def get_runtime():
@@ -59,6 +63,34 @@ def run_model(onnx_model, data_inputs):
     else:
         raise RuntimeError('The requested nGraph backend <' + NgraphBackend.backend_name +
                            '> is not supported!')
+
+
+def get_node_model(op_type, *input_data, opset=1, num_outputs=1, **node_attributes):
+    # type: (str, Any, Optional[int], Optional[int], Optional[Any]) -> onnx.ModelProto
+    """Generate model with single requested node.
+
+    :param op_type: The ONNX node operation.
+    :param input_data: Optional list of input arguments for node.
+    :param opset: The ONNX operation set version to use. Default to 4.
+    :param num_outputs: The number of node outputs.
+    :param node_attributes: Optional dictionary of node attributes.
+    :return: Generated model with single node for requested ONNX operation.
+    """
+    node_inputs = [np.array(data) for data in input_data]
+    num_inputs = len(node_inputs)
+    node_input_names = [ascii_uppercase[idx] for idx in range(num_inputs)]
+    node_output_names = [ascii_uppercase[num_inputs + idx] for idx in range(num_outputs)]
+    onnx_node = make_node(op_type, node_input_names, node_output_names, **node_attributes)
+
+    input_tensors = [make_tensor_value_info(name, onnx.TensorProto.FLOAT, value.shape)
+                     for name, value in zip(onnx_node.input, node_inputs)]
+    output_tensors = [make_tensor_value_info(name, onnx.TensorProto.FLOAT, value.shape)
+                      for name, value in zip(onnx_node.output, ())]  # type: ignore
+
+    graph = make_graph([onnx_node], 'compute_graph', input_tensors, output_tensors)
+    model = make_model(graph, producer_name='NgraphBackend')
+    model.opset_import[0].version = opset
+    return model
 
 
 def all_arrays_equal(first_list, second_list):


### PR DESCRIPTION
- Pad-1, Pad-2
- No support for Split-1 (optional input with split lengths and no default value for 'axis' attribute) since adding additional `if` statements to current `Split` function makes flake8 complain about it to be too complex. 
- No support for Concat-1 default value of `axis` attribute.