### PR TITLE
Handle only supported auto_pad modes.

### DIFF
--- a/ngraph_onnx/onnx_importer/utils/conv.py
+++ b/ngraph_onnx/onnx_importer/utils/conv.py
@@ -58,8 +58,14 @@ def get_pads(onnx_node, kernel_shape=None):
     if len(pads) == 0:
         pads = [0] * len(kernel_shape)
 
-    # Attribute 'auto_pad' is deprecated, but is currently used by CNTK
-    if auto_pad:
+    auto_pad_modes = [
+        'VALID',
+        'SAME_UPPER',
+        'SAME_LOWER',
+    ]
+
+    # Attribute 'auto_pad' is deprecated, but is currently used by CNTK.
+    if auto_pad in auto_pad_modes:
         if auto_pad == 'VALID':
             pads = [0, 0] * len(kernel_shape)
 

--- a/ngraph_onnx/onnx_importer/utils/conv.py
+++ b/ngraph_onnx/onnx_importer/utils/conv.py
@@ -58,29 +58,22 @@ def get_pads(onnx_node, kernel_shape=None):
     if len(pads) == 0:
         pads = [0] * len(kernel_shape)
 
-    auto_pad_modes = [
-        'VALID',
-        'SAME_UPPER',
-        'SAME_LOWER',
-    ]
-
     # Attribute 'auto_pad' is deprecated, but is currently used by CNTK.
-    if auto_pad in auto_pad_modes:
-        if auto_pad == 'VALID':
-            pads = [0, 0] * len(kernel_shape)
+    if auto_pad == 'VALID':
+        pads = [0, 0] * len(kernel_shape)
 
-        else:
-            # SAME_UPPER or SAME_LOWER mean pad the input so that the output size match the input.
-            # In case of odd number add the extra padding at the end for SAME_UPPER and at the
-            # beginning for SAME_LOWER.
-            def pad_value(kernel_dim):  # type: (int) -> float
-                return (kernel_dim - 1.0) / 2.0
+    elif auto_pad == 'SAME_UPPER' or auto_pad == 'SAME_LOWER':
+        # SAME_UPPER or SAME_LOWER mean pad the input so that the output size match the input.
+        # In case of odd number add the extra padding at the end for SAME_UPPER and at the
+        # beginning for SAME_LOWER.
+        def pad_value(kernel_dim):  # type: (int) -> float
+            return (kernel_dim - 1.0) / 2.0
 
-            pads_starts = [floor(pad_value(dim)) if auto_pad == 'SAME_UPPER' else
-                           ceil(pad_value(dim)) for dim in kernel_shape]
-            pads_ends = [ceil(pad_value(dim)) if auto_pad == 'SAME_UPPER' else
-                         floor(pad_value(dim)) for dim in kernel_shape]
-            pads = pads_starts + pads_ends
+        pads_starts = [floor(pad_value(dim)) if auto_pad == 'SAME_UPPER' else
+                       ceil(pad_value(dim)) for dim in kernel_shape]
+        pads_ends = [ceil(pad_value(dim)) if auto_pad == 'SAME_UPPER' else
+                     floor(pad_value(dim)) for dim in kernel_shape]
+        pads = pads_starts + pads_ends
 
     if len(pads) <= 3:
         padding_above = pads


### PR DESCRIPTION
This fixes bug, when model provides both 'pads' attribute and any string inside 'auto_pad' attribute, which takes precedence of 'pads'.