### PR TITLE
[ONNX CI] Watchdog - separate config files for different projects

### DIFF
--- a/.ci/watchdog/Watchdog.py
+++ b/.ci/watchdog/Watchdog.py
@@ -230,10 +230,8 @@ class Watchdog:
             :return:            Returns build number
             :rtype:             int
         """
-        # Get oldest build number
-        # job_info = self._jenkins.get_job_info(self._ci_job_name)
         # Retrieve the build number from url string
-        match_obj = re.search('(?:/' + self._ci_job_name.split('/')[-1] + '/)([0-9]+)', url)
+        match_obj = re.search('(?:/PR-[0-9]+/)([0-9]+)', url)
         try:
             number = int(match_obj.group(1))
             return number
@@ -279,7 +277,8 @@ class Watchdog:
         pr_number = str(pr.number)
         log.info('CI for PR %s: FINISHED', pr_number)
         # Check if FINISH was valid FAIL / SUCCESS
-        build_output = self._jenkins.get_build_console_output(self._ci_job_name, build_number)
+        project_name_full = self._ci_job_name + '/PR-' + pr_number
+        build_output = self._jenkins.get_build_console_output(project_name_full, build_number)
         if _CI_BUILD_FAIL_MESSAGE not in build_output \
                 and _CI_BUILD_SUCCESS_MESSAGE not in build_output:
             message = ('ONNX CI job for PR #{} finished but no tests success or fail '
@@ -340,7 +339,8 @@ class Watchdog:
         """
         pr_number = str(pr.number)
         log.info('CI for PR %s: TESTING IN PROGRESS', pr_number)
-        build_info = self._jenkins.get_build_info(self._ci_job_name, build_number)
+        project_name_full = self._ci_job_name + '/PR-' + pr_number
+        build_info = self._jenkins.get_build_info(project_name_full, build_number)
         build_datetime = datetime.datetime.fromtimestamp(build_info['timestamp'] / 1000.0)
         # If build still waiting in queue
         queue_item = self._jenkins.get_queue_item(build_info['queueId'])

--- a/.ci/watchdog/Watchdog.py
+++ b/.ci/watchdog/Watchdog.py
@@ -42,7 +42,6 @@ ch.setFormatter(logging.Formatter('%(name)s - %(levelname)s - %(message)s'))
 log.addHandler(ch)
 
 # Watchdog static constant variables
-_CONFIG_PATH = '/tmp/onnx_ci_watchdog.json'
 _BUILD_DURATION_THRESHOLD = datetime.timedelta(minutes=60)
 _CI_START_THRESHOLD = datetime.timedelta(minutes=10)
 _AWAITING_JENKINS_THRESHOLD = datetime.timedelta(minutes=5)
@@ -81,6 +80,7 @@ class Watchdog:
 
     def __init__(self, jenkins_token, jenkins_server, jenkins_user, git_token, git_org,
                  git_project, slack_token, ci_job_name, watchdog_job_name):
+        self._config_path = '/tmp/' + git_project + '_ci_watchdog.json'
         # Jenkins Wrapper object for CI job
         self._jenkins = JenkinsWrapper(jenkins_token,
                                        jenkins_user=jenkins_user,
@@ -126,9 +126,9 @@ class Watchdog:
             :return:            Returns dict of dicts with reported fails with their timestamps
             :rtype:             dict of dicts
         """
-        if os.path.isfile(_CONFIG_PATH):
+        if os.path.isfile(self._config_path):
             log.info('Config file exists, reading.')
-            file = open(_CONFIG_PATH, 'r')
+            file = open(self._config_path, 'r')
             data = json.load(file)
         else:
             log.info('No config file.')
@@ -397,5 +397,5 @@ class Watchdog:
             if pr not in current_prs:
                 self._config[_PR_REPORTS_CONFIG_KEY].pop(pr)
         log.info('Writing to config file.')
-        file = open(_CONFIG_PATH, 'w+')
+        file = open(self._config_path, 'w+')
         json.dump(self._config, file)

--- a/.ci/watchdog/Watchdog.py
+++ b/.ci/watchdog/Watchdog.py
@@ -45,7 +45,7 @@ log.addHandler(ch)
 _BUILD_DURATION_THRESHOLD = datetime.timedelta(minutes=60)
 _CI_START_THRESHOLD = datetime.timedelta(minutes=10)
 _AWAITING_JENKINS_THRESHOLD = datetime.timedelta(minutes=5)
-_WATCHDOG_DIR = '~'
+_WATCHDOG_DIR = os.path.expanduser("~")
 _PR_REPORTS_CONFIG_KEY = 'pr_reports'
 _CI_BUILD_FAIL_MESSAGE = 'ERROR:   py3: commands failed'
 _CI_BUILD_SUCCESS_MESSAGE = 'py3: commands succeeded'
@@ -81,7 +81,7 @@ class Watchdog:
 
     def __init__(self, jenkins_token, jenkins_server, jenkins_user, git_token, git_org,
                  git_project, slack_token, ci_job_name, watchdog_job_name):
-        self._config_path = '{}/.{}_ci_watchdog.json'.format(_WATCHDOG_DIR, git_project)
+        self._config_path = os.path.join(_WATCHDOG_DIR, '{}/.{}_ci_watchdog.json'.format(_WATCHDOG_DIR, git_project))
         # Jenkins Wrapper object for CI job
         self._jenkins = JenkinsWrapper(jenkins_token,
                                        jenkins_user=jenkins_user,

--- a/.ci/watchdog/Watchdog.py
+++ b/.ci/watchdog/Watchdog.py
@@ -114,7 +114,6 @@ class Watchdog:
             self._queue_message(str(e), message_severity=999)
         self._send_message()
 
-    @staticmethod
     def _read_config_file():
         """Read Watchdog config file stored on the system.
 

--- a/.ci/watchdog/Watchdog.py
+++ b/.ci/watchdog/Watchdog.py
@@ -114,7 +114,7 @@ class Watchdog:
             self._queue_message(str(e), message_severity=999)
         self._send_message()
 
-    def _read_config_file():
+    def _read_config_file(self):
         """Read Watchdog config file stored on the system.
 
         The file stores every fail already reported along with timestamp. This

--- a/.ci/watchdog/Watchdog.py
+++ b/.ci/watchdog/Watchdog.py
@@ -45,7 +45,7 @@ log.addHandler(ch)
 _BUILD_DURATION_THRESHOLD = datetime.timedelta(minutes=60)
 _CI_START_THRESHOLD = datetime.timedelta(minutes=10)
 _AWAITING_JENKINS_THRESHOLD = datetime.timedelta(minutes=5)
-_WATCHDOG_DIR = os.path.expanduser("~")
+_WATCHDOG_DIR = os.path.expanduser('~')
 _PR_REPORTS_CONFIG_KEY = 'pr_reports'
 _CI_BUILD_FAIL_MESSAGE = 'ERROR:   py3: commands failed'
 _CI_BUILD_SUCCESS_MESSAGE = 'py3: commands succeeded'


### PR DESCRIPTION
Config file generated based on git project name. Fixes config file being overwritten by multiple watchdog jobs, resulting in unnecesary notifications.