### PR TITLE
Remove redundant test

### DIFF
--- a/tests_core/test_graph_import.py
+++ b/tests_core/test_graph_import.py
@@ -18,7 +18,6 @@ from __future__ import print_function, division
 
 import onnx
 import numpy as np
-import pytest
 
 from tests_core.utils import get_runtime
 from onnx.helper import make_node, make_graph, make_tensor_value_info, make_model
@@ -42,17 +41,3 @@ def test_simple_graph():
     computation = runtime.computation(ng_model_function)
     assert np.array_equal(computation(1, 2, 3)[0], np.array([6.0], dtype=np.float32))
     assert np.array_equal(computation(4, 5, 6)[0], np.array([15.0], dtype=np.float32))
-
-
-def test_missing_op():
-    node = make_node('FakeOpName', ['A'], ['X'], name='missing_op_node')
-    graph = make_graph([node], 'test_graph',
-                       [make_tensor_value_info('A', onnx.TensorProto.FLOAT, [1])],
-                       [make_tensor_value_info('X', onnx.TensorProto.FLOAT, [1])])
-    model = make_model(graph, producer_name='ngraph ONNXImporter')
-
-    with pytest.raises(RuntimeError) as exc_info:
-        import_onnx_model(model)
-
-    exc_args = exc_info.value.args
-    assert 'unknown operations: FakeOpName' in str(exc_args[0] % exc_args[1:])


### PR DESCRIPTION
This test case is covered in nGraph core C++ tests.