### PR TITLE
[ONNX CI] Add fallback for getting current time

### DIFF
--- a/.ci/watchdog/GitWrapper.py
+++ b/.ci/watchdog/GitWrapper.py
@@ -70,7 +70,7 @@ class GitWrapper:
             :rtype:                     datetime
         """
         try:
-            datetime_string = self.git.get_api_status().raw_headers['date']
+            datetime_string = self.git.get_api_status().raw_headers.get('date', '')
             datetime_object = datetime.strptime(datetime_string, '%a, %d %b %Y %H:%M:%S %Z')
         except ValueError:
             log.exception('Failed to parse date retrieved from GitHub: %s', str(datetime_string))

--- a/.ci/watchdog/GitWrapper.py
+++ b/.ci/watchdog/GitWrapper.py
@@ -76,7 +76,7 @@ class GitWrapper:
             log.exception('Failed to parse date retrieved from GitHub: %s', str(datetime_string))
             raise
         except Github.GithubException.GithubException as e:
-            log.exception("Exception during API status retrieval. Exception: {}".format(str(e)))
+            log.exception('Exception during API status retrieval. Exception: {}'.format(str(e)))
             raise
         return datetime_object
 

--- a/.ci/watchdog/GitWrapper.py
+++ b/.ci/watchdog/GitWrapper.py
@@ -69,11 +69,14 @@ class GitWrapper:
             :return:                    Datetime object describing current time
             :rtype:                     datetime
         """
-        datetime_string = self.git.get_api_status().raw_headers['date']
         try:
+            datetime_string = self.git.get_api_status().raw_headers['date']
             datetime_object = datetime.strptime(datetime_string, '%a, %d %b %Y %H:%M:%S %Z')
         except ValueError:
             log.exception('Failed to parse date retrieved from GitHub: %s', str(datetime_string))
+            raise
+        except Github.GithubException.GithubException as e:
+            log.exception("Exception during API status retrieval. Exception: {}".format(str(e)))
             raise
         return datetime_object
 

--- a/.ci/watchdog/GitWrapper.py
+++ b/.ci/watchdog/GitWrapper.py
@@ -27,7 +27,7 @@
 import logging
 from datetime import datetime
 from retrying import retry
-from github import Github
+from github import Github, GithubException
 
 # Logging
 log = logging.getLogger(__name__)
@@ -75,7 +75,7 @@ class GitWrapper:
         except ValueError:
             log.exception('Failed to parse date retrieved from GitHub: %s', str(datetime_string))
             raise
-        except Github.GithubException.GithubException as e:
+        except GithubException as e:
             log.exception('Exception during API status retrieval. Exception: {}'.format(str(e)))
             raise
         return datetime_object

--- a/.ci/watchdog/Watchdog.py
+++ b/.ci/watchdog/Watchdog.py
@@ -97,7 +97,7 @@ class Watchdog:
         # Read config file
         self._config = self._read_config_file()
         # Time at Watchdog initiation
-        self._now_time = self._git.get_git_time()
+        self._now_time = self._get_current_time()
 
     def run(self, quiet=False):
         """Run main watchdog logic.
@@ -123,6 +123,14 @@ class Watchdog:
                 self._queue_message(str(e), message_severity='internal')
         self._update_config()
         self._send_message(quiet=quiet)
+
+    def _get_current_time(self):
+        try:
+            now_time = self._git.get_git_time()
+        except Exception:
+            log.warning('Falling back to system time! This can produce invalid results if system time is not set correctly!')
+            now_time = datetime.datetime.now()
+        return now_time
 
     def _read_config_file(self):
         """Read Watchdog config file stored on the system.

--- a/.ci/watchdog/Watchdog.py
+++ b/.ci/watchdog/Watchdog.py
@@ -128,7 +128,7 @@ class Watchdog:
         try:
             now_time = self._git.get_git_time()
         except Exception:
-            message = 'Falling back to system time! This can produce invalid results if system time is not set correctly!'
+            message = 'Falling back to system time! This can produce invalid results!'
             self._queue_message(message, message_severity='internal')
             now_time = datetime.datetime.now()
         return now_time

--- a/.ci/watchdog/Watchdog.py
+++ b/.ci/watchdog/Watchdog.py
@@ -32,6 +32,7 @@ from SlackCommunicator import SlackCommunicator
 from JenkinsWrapper import JenkinsWrapper
 from jenkins import NotFoundException
 from GitWrapper import GitWrapper
+from github import GithubException
 import os
 import json
 
@@ -127,7 +128,7 @@ class Watchdog:
     def _get_current_time(self):
         try:
             now_time = self._git.get_git_time()
-        except Exception:
+        except (ValueError, GithubException):
             message = 'Falling back to system time! This can produce invalid results!'
             self._queue_message(message, message_severity='internal')
             now_time = datetime.datetime.now()

--- a/.ci/watchdog/Watchdog.py
+++ b/.ci/watchdog/Watchdog.py
@@ -128,7 +128,8 @@ class Watchdog:
         try:
             now_time = self._git.get_git_time()
         except Exception:
-            log.warning('Falling back to system time! This can produce invalid results if system time is not set correctly!')
+            message = 'Falling back to system time! This can produce invalid results if system time is not set correctly!'
+            self._queue_message(message, message_severity='internal')
             now_time = datetime.datetime.now()
         return now_time
 


### PR DESCRIPTION
**Current situation:**
Current time is retrieved from GitHub API to avoid discrepencies between dates on PR and time on system that Watchdog is running on.

**Problem:**
Github API Status is failing, returning "404: not found"

**Solution:**
Assess if failure is due to bug or API change. As workaround provide fallback relying on system time.

**Risks:**
System time has to be synchronized.