### PR TITLE
Enable using backend module without explicit import NgraphBackend class

### DIFF
--- a/ngraph_onnx/onnx_importer/backend.py
+++ b/ngraph_onnx/onnx_importer/backend.py
@@ -163,3 +163,9 @@ class NgraphBackendRep(BackendRep):
 
     def _get_ngraph_device_name(self, onnx_device):  # type: (str) -> str
         return 'GPU' if onnx_device == 'CUDA' else onnx_device
+
+
+prepare = NgraphBackend.prepare
+run_model = NgraphBackend.run_model
+run_node = NgraphBackend.run_node
+supports_device = NgraphBackend.supports_device

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -6,5 +6,5 @@ flake8-commas==2.0.0
 flake8-comprehensions==2.1.0
 flake8-docstrings==1.3.0
 flake8-quotes==2.0.1
-mypy==0.711
+mypy==0.720
 pydocstyle==3.0.0

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -22,7 +22,7 @@ from __future__ import unicode_literals
 import onnx.backend.test
 import pytest
 
-from ngraph_onnx.onnx_importer.backend import NgraphBackend
+import ngraph_onnx.onnx_importer.backend as NgraphBackend
 
 import tests.utils
 

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -22,20 +22,20 @@ from __future__ import unicode_literals
 import onnx.backend.test
 import pytest
 
-import ngraph_onnx.onnx_importer.backend as NgraphBackend
+import ngraph_onnx.onnx_importer.backend as ng_backend
 
 import tests.utils
 
 # Set backend device name to be used instead of hardcoded by ONNX BackendTest class ones.
 selected_backend_name = tests.utils.BACKEND_NAME
-NgraphBackend.backend_name = selected_backend_name
+ng_backend.NgraphBackend.backend_name = selected_backend_name
 
 # This is a pytest magic variable to load extra plugins
 # Uncomment the line below to enable the ONNX compatibility report
 # pytest_plugins = 'onnx.backend.test.report',
 
 # import all test cases at global scope to make them visible to python.unittest
-backend_test = onnx.backend.test.BackendTest(NgraphBackend, __name__)
+backend_test = onnx.backend.test.BackendTest(ng_backend, __name__)
 
 # MaxPool Indices -> NGRAPH-3131
 backend_test.exclude('test_maxpool_with_argmax')


### PR DESCRIPTION
Made aliases for NgraphBackend class methods  to follow other frameworks convention.