### PR TITLE
Update requirements_test.txt

### DIFF
--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -7,4 +7,5 @@ flake8-comprehensions==2.1.0
 flake8-docstrings==1.3.0
 flake8-quotes==2.0.1
 mypy==0.720
-pydocstyle==3.0.0
+pydocstyle==3.0.0  # Pinned due to an error, remove when possible
+pyparsing==2.4.0  # Pinned due to warnings, remove when possible


### PR DESCRIPTION
We're seeing warnings in CI:

```
/usr/local/lib/python3.5/dist-packages/packaging/requirements.py:57: UserWarning: warn_ungrouped_named_tokens_in_collection: setting results name 'specifier' on And expression collides with '_original_end' on contained expression
  VERSION_SPEC = originalTextFor(_VERSION_SPEC)("specifier")
/usr/local/lib/python3.5/dist-packages/packaging/requirements.py:60: UserWarning: warn_ungrouped_named_tokens_in_collection: setting results name 'marker' on And expression collides with '_original_end' on contained expression
```

This is related to:
https://github.com/pypa/packaging/issues/170

Pinning `pyparsing==2.4.0` as a workaround.