### PR TITLE
[ONNX CI] Using baremetal user in Docker container

### DIFF
--- a/.ci/jenkins/dockerfiles/postprocess/append_user.dockerfile
+++ b/.ci/jenkins/dockerfiles/postprocess/append_user.dockerfile
@@ -1,0 +1,12 @@
+# This dockerfile is used to add user to Docker image matching the one executing CI
+ARG base_image
+FROM ${base_image}
+
+ARG USERNAME
+ARG UID
+ARG GID
+
+# Add user and group
+RUN groupadd -g $GID -o $USERNAME
+RUN useradd -m -u $UID -g $GID -o -s /bin/bash $USERNAME
+USER $USERNAME

--- a/.ci/jenkins/prepare_environment.sh
+++ b/.ci/jenkins/prepare_environment.sh
@@ -59,12 +59,21 @@ function main() {
     # By default copy stored nGraph master and use it to build PR branch
     BACKEND="cpu"
 
+    NUM_PARAMETERS="2"
+    if [ $# -lt "${NUM_PARAMETERS}" ]; then
+        echo "ERROR: Expected at least ${NUM_PARAMETERS} parameter got $#"
+        exit 1
+    fi
+
     PATTERN='[-a-zA-Z0-9_]*='
     for i in "$@"
     do
         case $i in
             --backend=*)
                 BACKEND="${i//${PATTERN}/}"
+                ;;
+            --build-dir=*)
+                BUILD_DIR="${i//${PATTERN}/}"
                 ;;
             *)
                 echo "Parameter $i not recognized."
@@ -73,11 +82,7 @@ function main() {
         esac
     done
 
-    BUILD_CALL="build_ngraph \"/root\" \"${BACKEND}\""
-    # Link ONNX models
-    mkdir -p /home/onnx_models/.onnx
-    ln -s /home/onnx_models/.onnx /root/.onnx
-
+    BUILD_CALL="build_ngraph \"${BUILD_DIR}\" \"${BACKEND}\""
     eval "${BUILD_CALL}"
 }
 


### PR DESCRIPTION
Previously user inside Docker container running CI was `root`. This caused all the files produced during CI to be owned by `root` user, in turn causing cleanup stage to be tricky and sometimes fail if previous run was cancelled before proper cleanup inside container completed.

This commit fixes the issue and simplifies cleanup, by adding user inside Docker image.

**Previous workflow**
- Pull Docker image from Docker registry
- Run Docker container, user inside container is `root`
- Run cleanup from inside container

**New workflow**
- Pull Docker image from Docker registry
- Build `append_user.dockerfile`, using image pulled above as base - this makes sure that user running CI is added to Docker image
- Run Docker container using image with appended user, in our setup it will always be `lab_nerval`
- After CI finishes, cleanup can be simply executed from baremetal level