### PR TITLE
[ONNX] Enable DepthToSpace unit tests

### DIFF
--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -308,7 +308,7 @@ expect_fail('OnnxBackendNodeModelTest.test_constant_pad_cpu')
 expect_fail('OnnxBackendNodeModelTest.test_edge_pad_cpu')
 expect_fail('OnnxBackendNodeModelTest.test_reflect_pad_cpu')
 
-# DynamicQuantizeLinear - NGONNX-786\
+# DynamicQuantizeLinear - NGONNX-786
 expect_fail('OnnxBackendNodeModelTest.test_dynamicquantizelinear_cpu')
 expect_fail('OnnxBackendNodeModelTest.test_dynamicquantizelinear_expanded_cpu')
 expect_fail('OnnxBackendNodeModelTest.test_dynamicquantizelinear_max_adjusted_cpu')

--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -308,11 +308,7 @@ expect_fail('OnnxBackendNodeModelTest.test_constant_pad_cpu')
 expect_fail('OnnxBackendNodeModelTest.test_edge_pad_cpu')
 expect_fail('OnnxBackendNodeModelTest.test_reflect_pad_cpu')
 
-# DepthToSpace CRD mode - NGONNX-784
-expect_fail('OnnxBackendNodeModelTest.test_depthtospace_crd_mode_cpu')
-expect_fail('OnnxBackendNodeModelTest.test_depthtospace_crd_mode_example_cpu')
-
-# DynamicQuantizeLinear - NGONNX-786
+# DynamicQuantizeLinear - NGONNX-786\
 expect_fail('OnnxBackendNodeModelTest.test_dynamicquantizelinear_cpu')
 expect_fail('OnnxBackendNodeModelTest.test_dynamicquantizelinear_expanded_cpu')
 expect_fail('OnnxBackendNodeModelTest.test_dynamicquantizelinear_max_adjusted_cpu')


### PR DESCRIPTION
As a result of `DepthToSpace` `mode` support (https://github.com/NervanaSystems/ngraph/pull/3820):- 
- `test_depthtospace_crd_mode_cpu`
- `test_depthtospace_crd_mode_example_cpu`

should be enabled