### PR TITLE
Temporarily disable tests failing on INTERPRETER

### DIFF
--- a/tests/test_backend.py
+++ b/tests/test_backend.py
@@ -75,6 +75,23 @@ backend_test.exclude('test_zfnet512')
 # Support for ONNX Sequence type - NGONNX-789
 backend_test.exclude('test_sequence_model')
 
+
+# Tests which fail on the CPU backend -> NC-330
+backend_test.exclude('test_Conv3d_dilated')
+backend_test.exclude('test_Conv3d_dilated_strided')
+
+# Tests temporarily disabled.
+# Re-enable, when https://github.com/NervanaSystems/ngraph/pull/4036 is merged.
+if selected_backend_name == 'INTERPRETER':
+    backend_test.exclude('test_Conv')
+    backend_test.exclude('test_GLU')
+    backend_test.exclude('test_operator_chunk')
+    backend_test.exclude('test_reduce_log_sum_exp')
+    backend_test.exclude('test_split')
+    backend_test.exclude('test_operator_conv_cpu')
+
+# NOTE: ALL backend_test.exclude CALLS MUST BE PERFORMED BEFORE THE CALL TO globals().update
+
 OnnxBackendNodeModelTest = None
 OnnxBackendSimpleModelTest = None
 OnnxBackendPyTorchOperatorModelTest = None
@@ -350,7 +367,6 @@ if selected_backend_name == 'INTELGPU':
 
 # Tests which fail or are very slow on the INTERPRETER backend
 if selected_backend_name == 'INTERPRETER':
-    backend_test.exclude('test_operator_conv_cpu')
     # Cast -> NGONNX-764
     expect_fail('OnnxBackendNodeModelTest.test_cast_DOUBLE_to_FLOAT16_cpu')
     expect_fail('OnnxBackendNodeModelTest.test_cast_FLOAT_to_FLOAT16_cpu')
@@ -363,9 +379,6 @@ if selected_backend_name == 'CPU':
     expect_fail('OnnxBackendNodeModelTest.test_cast_FLOAT_to_FLOAT16_cpu')
     expect_fail('OnnxBackendNodeModelTest.test_cast_FLOAT16_to_DOUBLE_cpu')
     expect_fail('OnnxBackendNodeModelTest.test_cast_FLOAT16_to_FLOAT_cpu')
-    # Tests which fail on the CPU backend -> NC-330
-    backend_test.exclude('test_Conv3d_dilated')
-    backend_test.exclude('test_Conv3d_dilated_strided')
 
 if selected_backend_name == 'PlaidML':
     expect_fail('OnnxBackendPyTorchConvertedModelTest.test_Embedding_cpu')
@@ -384,7 +397,6 @@ if selected_backend_name == 'PlaidML':
     expect_fail('OnnxBackendNodeModelTest.test_cumsum_2d_axis_0_cpu')
     expect_fail('OnnxBackendNodeModelTest.test_cumsum_2d_axis_1_cpu')
     expect_fail('OnnxBackendNodeModelTest.test_cumsum_2d_negative_axis_cpu')
-    expect_fail('OnnxBackendNodeModelTest.test_edge_pad_cpu')
     expect_fail('OnnxBackendNodeModelTest.test_edge_pad_cpu')
     expect_fail('OnnxBackendNodeModelTest.test_erf_cpu')
     expect_fail('OnnxBackendNodeModelTest.test_gather_0_cpu')

--- a/tests/test_reshape.py
+++ b/tests/test_reshape.py
@@ -240,6 +240,7 @@ def test_unsqueeze():
     assert np.array_equal(ng_results, [expected_output])
 
 
+@pytest.mark.skip_on_interpreter  # TODO: remove after https://github.com/NervanaSystems/ngraph/pull/4036
 @pytest.mark.parametrize('node, expected_output', [
     # Split into 2 equal parts along axis=0
     (onnx.helper.make_node('Split', inputs=['x'], outputs=['y', 'z'], axis=0),
@@ -267,6 +268,7 @@ def test_split_2d(node, expected_output):
     assert all_arrays_equal(ng_results, expected_output)
 
 
+@pytest.mark.skip_on_interpreter  # TODO: remove after https://github.com/NervanaSystems/ngraph/pull/4036
 def test_split_1d():
     # 1D
     data = np.array([1., 2., 3., 4., 5., 6.]).astype(np.float32)


### PR DESCRIPTION
Temporarily disabling tests which are failing on INTERPRETER due to lack of decomposition after the downgrade pass. 

See this PR for a pending fix:
https://github.com/NervanaSystems/ngraph/pull/4036