### PR TITLE
Update BERT models paths

### DIFF
--- a/tests/test_zoo_models.py
+++ b/tests/test_zoo_models.py
@@ -38,11 +38,11 @@ zoo_models = [
     # BERT-Squad
     {
         'model_name': 'bert_squad_opset8',
-        'url': _GITHUB_ONNX_MASTER + 'text/machine_comprehension/bert-squad/model/download_sample_8.tar.gz',
+        'url': _GITHUB_ONNX_MASTER + 'text/machine_comprehension/bert-squad/model/bertsquad-8.tar.gz',
     },
     {
         'model_name': 'bert_squad_opset10',
-        'url': _GITHUB_ONNX_MASTER + 'text/machine_comprehension/bert-squad/model/download_sample_10.tar.gz',
+        'url': _GITHUB_ONNX_MASTER + 'text/machine_comprehension/bert-squad/model/bertsquad-10.tar.gz',
     },
 
     # BiDAF


### PR DESCRIPTION
Paths to BERT models in ONNX repo were changed in: https://github.com/onnx/models/commit/c02f8c8699fc12273649e658b8d2a1a8e32a35d0#diff-4208b5b4ac4fa9d7b891da85e7846890