### PR TITLE
Specify tox python version to python3.6.x

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py3
+envlist = py36
 
 [testenv]
 skipdist=True


### PR DESCRIPTION
Specify to use python 3.6.x. only (for CI purposes)